### PR TITLE
readme: switch image size badge to shields.io for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Duo AuthProxy on Linux
 ======================
 
-[![](https://badge.imagelayers.io/jumanjiman/duoauthproxy.svg)](https://imagelayers.io/?images=jumanjiman/duoauthproxy:latest 'View image size and layers')&nbsp;
+[![Image Size](https://img.shields.io/imagelayers/image-size/jumanjiman/duoauthproxy/latest.svg)](https://imagelayers.io/?images=jumanjiman/duoauthproxy:latest 'View image size and layers')&nbsp;
 [![Docker Registry](https://img.shields.io/docker/pulls/jumanjiman/duoauthproxy.svg)](https://registry.hub.docker.com/u/jumanjiman/duoauthproxy)&nbsp;
 [![Circle CI](https://circleci.com/gh/jumanjihouse/docker-duoauthproxy.png?circle-token=08f5a2b5348f48e4e629da800f3e0ad410025dca)](https://circleci.com/gh/jumanjihouse/docker-duoauthproxy/tree/master 'View CI builds')
 

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -17,7 +17,7 @@ RUN apk upgrade --update --available && \
       libffi-dev \
       libgcc \
       make \
-      openssl-dev=1.0.2d-r0 \
+      openssl-dev=1.0.2e-r0 \
       patch \
       py-setuptools \
       python-dev \


### PR DESCRIPTION
The shields.io badges look better to me, plus
this provides consistency across the look of the badges.