### PR TITLE
remove bash from runtime since it is not needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,8 +246,9 @@ Output resembles:
     ✓ duo group exists
     ✓ duo is the only group account
     ✓ duo is the only group account
+    ✓ bash is not installed
 
-    10 tests, 0 failures
+    11 tests, 0 failures
 
 Licenses
 --------

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.3
 
 RUN apk upgrade --update && \
-    apk add bash python && \
+    apk add python && \
     rm -f /var/cache/apk/* && \
     adduser -D -s /sbin/nologin duo
 

--- a/test/test_harden.bats
+++ b/test/test_harden.bats
@@ -43,3 +43,8 @@
   groups=$(docker run --rm --entrypoint getent duoauthproxy group | wc -l)
   [[ ${groups} -eq 1 ]]
 }
+
+@test "bash is not installed" {
+  run docker run --rm --entrypoint ls duoauthproxy /bin/bash
+  [[ ${status} -ne 0 ]]
+}


### PR DESCRIPTION
I reviewed all the hits from this command inside the container:

    find /opt/duoauthproxy/ -type f -exec grep bash {} +

Bash appears to not be needed in the runtime,
so it improves our security posture to remove it.