### PR TITLE
upgrade to openssl 1.0.2f to resolve CVEs

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -17,7 +17,7 @@ RUN apk upgrade --update --available && \
       libffi-dev \
       libgcc \
       make \
-      openssl-dev=1.0.2e-r0 \
+      openssl-dev=1.0.2f-r0 \
       patch \
       py-setuptools \
       python-dev \


### PR DESCRIPTION
https://www.openssl.org/news/secadv/20160128.txt