### PR TITLE
upgrade to openssl 1.0.2g to resolve CVEs

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -7,6 +7,9 @@ FROM alpine:3.3
 ENV VERSION 2.4.14.1
 
 RUN apk upgrade --update --available && \
+    apk add --no-cache -X http://dl-4.alpinelinux.org/alpine/edge/main \
+      'openssl-dev>=1.0.2g-r0' \
+      && \
     apk add \
       bash \
       curl \
@@ -17,7 +20,6 @@ RUN apk upgrade --update --available && \
       libffi-dev \
       libgcc \
       make \
-      openssl-dev=1.0.2f-r0 \
       patch \
       py-setuptools \
       python-dev \

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -8,7 +8,7 @@ ENV VERSION 2.4.14.1
 
 RUN apk upgrade --update --available && \
     apk add --no-cache -X http://dl-4.alpinelinux.org/alpine/edge/main \
-      'openssl-dev>=1.0.2g-r0' \
+      'openssl-dev>=1.0.2g-r1' \
       && \
     apk add \
       bash \


### PR DESCRIPTION
https://openssl.org/news/cl102.txt

CVE-2016-0800 [High severity]
CVE-2016-0705 [Low severity]
CVE-2016-0798 [Low severity]
CVE-2016-0797 [Low severity]
CVE-2016-0799 [Low severity]
CVE-2016-0702 [Low severity]
CVE-2016-0703 [High severity]
CVE-2016-0704 [Moderate severity]