### PR TITLE
disable weak crypto in openssl

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -8,7 +8,7 @@ ENV VERSION 2.4.14.1
 
 RUN apk upgrade --update --available && \
     apk add --no-cache -X http://dl-4.alpinelinux.org/alpine/edge/main \
-      'openssl-dev>=1.0.2g-r1' \
+      'openssl-dev>=1.0.2g-r2' \
       && \
     apk add \
       bash \


### PR DESCRIPTION
http://git.alpinelinux.org/cgit/aports/commit/?id=012001f15d9e4c263bea96a79c9203c86952e7ce

* weak ciphers are removed
* SSL2 is still enabled to prevent ABI breakage