### PR TITLE
	Auto-generate authproxy.cfg from environment variables

### DIFF
--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -8,10 +8,14 @@ RUN apk upgrade --update && \
 # Use ADD, not COPY, to keep image small.
 ADD duoauthproxy.tgz /
 
+COPY entrypoint.py /
+COPY authproxy.cfg /etc/duoauthproxy/authproxy.cfg
+RUN chown duo /etc/duoauthproxy/authproxy.cfg
+
 COPY harden.sh /usr/sbin/harden.sh
 RUN /usr/sbin/harden.sh
 
-COPY authproxy.cfg /etc/duoauthproxy/authproxy.cfg
+ENV PATH /opt/duoauthproxy/bin:$PATH
 USER duo
-ENTRYPOINT ["/opt/duoauthproxy/bin/authproxy"]
-CMD ["-c", "/etc/duoauthproxy/authproxy.cfg"]
+ENTRYPOINT ["/entrypoint.py"]
+CMD ["authproxy", "-c", "/etc/duoauthproxy/authproxy.cfg"]

--- a/runtime/entrypoint.py
+++ b/runtime/entrypoint.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+import os
+import re
+import sys
+
+# default configuration values
+write_config = False
+config = {
+    'main': {
+        'log_stdout': 'true'
+    }
+}
+
+# read environment variables
+for key in os.environ.keys():
+    m = re.match('^DUO__(\w+)__(\w+)$', key)
+
+    if not m:
+        continue
+
+    write_config = True
+    section = m.group(1).lower()
+    option = m.group(2).lower()
+    value = os.environ.get(key)
+
+    if not config.get(section):
+        config[section] = {}
+
+    config[section][option] = value
+
+# generate cfg file
+if write_config:
+    f = open('/etc/duoauthproxy/authproxy.cfg', 'w')
+    for section in config.keys():
+        f.write('[{0}]\n'.format(section))
+
+        for option in config[section]:
+            value = config[section][option]
+            f.write('{0}={1}\n'.format(option, value))
+
+        f.write('\n')
+
+    f.close()
+
+# pass control to docker command
+os.execvp(sys.argv[1], sys.argv[1:])


### PR DESCRIPTION
(Request for feedback)

The `authproxy.cfg` file is inconvenient because it requires binding a volume from the docker host. In a distributed docker environment this is not a great way of handling configuration - it's much easier to pass in environment variables. I have modified this image to read all configuration from environment variables.

With the new setup, authproxy settings can be configured using environment variables named `DUO__SECTIONNAME__OPTIONNAME=value`.

For example:

``` sh
docker run -e CFG__RADIUS_CLIENT__HOST=hostname [...] -it duoauthproxy
```

The `entrypoint.py` file will automatically generate an `authproxy.cfg` file before launching the proxy.

If you are open to this approach, let me know any feedback on the PR, and I'm happy to update the readme with documentation. I have retained backwards compatibility for existing users by not modifying the `authproxy.cfg` file if no environment variables were specified. The only other change is that `/etc/duoauthproxy/authproxy.cfg` is now owned/writeable by the `duo` user, but I do not view this as a big security issue.
