### PR TITLE
upgrade openssl to 1.0.2i for CVEs

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -8,7 +8,7 @@ ENV VERSION 2.4.17
 
 RUN apk upgrade --update --available && \
     apk add --no-cache -X http://dl-4.alpinelinux.org/alpine/edge/main \
-      'openssl-dev>=1.0.2h-r4' \
+      'openssl-dev>=1.0.2i-r0' \
       && \
     apk add \
       bash \


### PR DESCRIPTION
https://www.openssl.org/news/openssl-1.0.2-notes.html