### PR TITLE
add label for CI build URL to refer back to circleci

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,24 @@ We push the tags automatically from the test harness, and
 we occasionally delete old tags from the Docker hub by hand.
 
 
+### View labels
+
+Each built image has labels that generally follow http://label-schema.org/
+
+We add a label, `ci-build-url`, that is not currently part of the schema.
+This extra label provides a permanent link to the CI build for the image.
+
+View the ci-build-url label on a built image:
+
+    docker inspect \
+      -f '{{ index .Config.Labels "io.github.jumanjiman.ci-build-url" }}' \
+      jumanjiman/duoauthproxy
+
+Query all the labels inside a built image:
+
+    docker inspect jumanjiman/duoauthproxy | jq -M '.[].Config.Labels'
+
+
 ### Configure the authproxy
 
 The image assumes the configuration is at `/etc/duoauthproxy/authproxy.cfg`

--- a/TESTING.md
+++ b/TESTING.md
@@ -67,5 +67,6 @@ Output resembles:
     ✓ chgrp is available
     ✓ ln is available
     ✓ chmod is available
+    ✓ ci-build-url label is present
 
-    15 tests, 0 failures
+    16 tests, 0 failures

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -1,10 +1,12 @@
 FROM alpine:3.4
 
+ARG CI_BUILD_URL
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
 
 LABEL \
+    io.github.jumanjiman.ci-build-url=$CI_BUILD_URL \
     io.github.jumanjiman.version=$VERSION \
     io.github.jumanjiman.build-date=$BUILD_DATE \
     io.github.jumanjiman.vcs-ref=$VCS_REF \

--- a/script/build.sh
+++ b/script/build.sh
@@ -17,6 +17,7 @@ smitty docker run --name builder duoauthproxy-builder bash -c "tar czf /tmp/duoa
 # NOTE: The build args are set by environment vars in circle.yml
 smitty docker cp builder:/tmp/duoauthproxy.tgz runtime/
 smitty docker build \
+  --build-arg CI_BUILD_URL=${CIRCLE_BUILD_URL} \
   --build-arg VCS_REF=${VCS_REF} \
   --build-arg BUILD_DATE=${BUILD_DATE} \
   --build-arg VERSION=${VERSION} \

--- a/test/test_labels.bats
+++ b/test/test_labels.bats
@@ -1,0 +1,6 @@
+@test "ci-build-url label is present" {
+  run docker inspect \
+      -f '{{ index .Config.Labels "io.github.jumanjiman.ci-build-url" }}' \
+      duoauthproxy
+  [[ ${output} =~ circleci.com ]]
+}


### PR DESCRIPTION
This allows to inspect a built image and refer back to
a permanent link for the build on circleci.

It depends on env var `CIRCLE_BUILD_URL`, which gets set
on every build as described at
https://circleci.com/docs/environment-variables/