### PR TITLE
alpine linux has switched from openssl to libressl

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -8,7 +8,7 @@ ENV VERSION 2.4.17
 
 RUN apk upgrade --update --available && \
     apk add --no-cache -X http://dl-4.alpinelinux.org/alpine/edge/main \
-      'openssl-dev>=1.0.2j-r0' \
+      'libressl-dev>=2.4.3-r1' \
       && \
     apk add \
       bash \

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -17,6 +17,9 @@ LABEL \
 
 RUN apk upgrade --update && \
     apk add python && \
+    apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/main \
+      'libressl2.4-libssl>=2.4.3-r1' \
+      && \
     rm -f /var/cache/apk/* && \
     adduser -D -s /sbin/nologin duo
 


### PR DESCRIPTION
Refs:

* https://twitter.com/n_copa/status/785456671627812865
* https://bugs.alpinelinux.org/issues/4970

____

let's see how this goes.
if it goes badly, we can always revert.