### PR TITLE
ci: resolve deploy failure on circleci

### DIFF
--- a/ci/build
+++ b/ci/build
@@ -5,7 +5,7 @@ cat > ci/vars <<EOF
   VERSION=2.4.21
   BUILD_DATE=$(date +%Y%m%dT%H%M)
   VCS_REF=${CIRCLE_SHA1:0:7}
-  TAG=${VERSION}-${BUILD_DATE}-git-${VCS_REF}
+  TAG=\${VERSION}-\${BUILD_DATE}-git-\${VCS_REF}
 
   # Tag for radiusd and radclient used in test harness.
   # For local testing, override this in "environment" as described in TESTING.md.


### PR DESCRIPTION
Resolves:

    Error parsing reference: "jumanjiman/duoauthproxy:--git-" is not a valid repository/tag
    Error parsing reference: "jumanjiman/duoauthproxy:--git-" is not a valid repository/tag