### PR TITLE
Update to AuthProxy v3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Docker hub: [https://registry.hub.docker.com/u/jumanjiman/duoauthproxy/](https:/
 <br />
 Image metadata: [https://microbadger.com/#/images/jumanjiman/duoauthproxy](https://microbadger.com/#/images/jumanjiman/duoauthproxy)
 <br />
-Current version: Duo Authproxy 2.11.0
+Current version: Duo Authproxy 3.0.0
 ([release notes](https://duo.com/support/documentation/authproxy-notes))
 
 

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -14,6 +14,7 @@ RUN \
       linux-headers \
       make \
       patch \
+      perl \
       procps \
       py-setuptools \
       python-devel \

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.5.1804
+FROM centos:7.6.1810
 
 RUN \
     yum install -y \

--- a/builder/build
+++ b/builder/build
@@ -34,4 +34,4 @@ PYTHON="$(command -v python)"
 declare -rx PYTHON
 make
 cd duoauthproxy-build
-./install --install-dir=/opt/duoauthproxy --service-user=duo --create-init-script=yes
+./install --install-dir=/opt/duoauthproxy --service-user=duo --log-group=duo --create-init-script=yes

--- a/ci/build
+++ b/ci/build
@@ -12,14 +12,14 @@ set -o pipefail
 
 cat >ci/vars <<EOF
 # shellcheck shell=bash
-declare -rx  VERSION=2.11.0
-declare -rx  BUILD_DATE=$(date +%Y%m%dT%H%M)
-declare -rx  VCS_REF=$(git describe --abbrev=7 --tags --always)
-declare -rx  TAG=\${VERSION}-\${BUILD_DATE}-git-\${VCS_REF}
+declare -rx VERSION=3.0.0
+declare -rx BUILD_DATE=$(date +%Y%m%dT%H%M)
+declare -rx VCS_REF=$(git describe --abbrev=7 --tags --always)
+declare -rx TAG=\${VERSION}-\${BUILD_DATE}-git-\${VCS_REF}
 
 # Tag for radiusd and radclient used in test harness.
 # For local testing, override this in "environment" as described in TESTING.md.
-declare -rx  RADIUS_TAG=\${RADIUS_TAG:-3.0.17-r2-20180707T2348-git-edb4d92}
+declare -rx RADIUS_TAG=\${RADIUS_TAG:-3.0.17-r2-20180707T2348-git-edb4d92}
 EOF
 
 # shellcheck disable=SC1091

--- a/contrib/authproxy.cfg
+++ b/contrib/authproxy.cfg
@@ -6,6 +6,8 @@
 [main]
 # Provide meaningful output for `docker logs <cid>`.
 log_stdout=true
+# use the CA certificates file supplied by the OS
+http_ca_certs_file=/etc/ssl/certs/ca-bundle.crt
 
 # Go through a corporate proxy to reach duo.
 http_proxy_host=proxy.example.com

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -69,7 +69,6 @@ services:
 
   radiusd:
     image: jumanjiman/radiusd:${RADIUS_TAG}
-    env_file: ci/vars
     command: -f -l stdout
     networks:
       testnet:

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.5.1804
+FROM centos:7.6.1810
 
 RUN \
     yum install -y \


### PR DESCRIPTION
This PR updates the bundled Duo Authentication Proxy to version 3.0.0 and uses CentOS 7.6 as the base image.
I added some fixes to problems I encountered when trying to build the container on Ubuntu 18.04.